### PR TITLE
Fix interop test fork location reference

### DIFF
--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Run on openwallet-foundation and non-draft PRs or on non-PR events
+    # Run on hyperledger and non-draft PRs or on non-PR events
     if: (github.repository == 'openwallet-foundation/acapy') && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event_name != 'pull_request'))
     outputs:
       is_release: ${{ steps.check_if_release.outputs.is_release }}
@@ -67,7 +67,7 @@ jobs:
           if [ ${{ github.event_name }} == 'pull_request' ]; then
             echo ${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}
             echo ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-            sed -i 's|@git+https://github.com/openwallet-foundation/acapy@main|@git+${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}@${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}|g' ./aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
+            sed -i 's|aries-cloudagent\[indy, bbs, askar\]@git+https://github.com/hyperledger/aries-cloudagent-python@main|acapy-agent[indy, bbs, askar]@git+${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}@${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}|g' ./aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
           fi
           cat aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
 


### PR DESCRIPTION
I think this should fix the interop tests. There's a text replace of this line https://github.com/hyperledger/aries-agent-test-harness/blob/main/aries-backchannels/acapy/requirements-main.txt#L1C35-L1C99 that loads the forked location. 

I'm not exactly sure if I need to change the `aries-cloudagent` reference here now or after the artifacts names have changed. 